### PR TITLE
chore(web): add Dockerfile for Next.js app

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+### Builder stage ###
+FROM node:20 AS builder
+
+WORKDIR /app
+# Enable pnpm via corepack
+RUN corepack enable
+
+# Copy the entire monorepo
+COPY . .
+
+# Install only the web workspace dependencies
+RUN pnpm install --filter web...
+
+# Build the Next.js application
+RUN pnpm --filter web... build
+
+### Runtime stage ###
+FROM node:20 AS runner
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Copy production node_modules and built app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/web ./apps/web
+
+# Expose the default Next.js port
+EXPOSE 3000
+
+# Run the Next.js application
+WORKDIR /app/apps/web
+CMD ["node_modules/.bin/next", "start"]
+


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for web app using Node 20 and pnpm

## Testing
- `pnpm install --filter web...`
- `pnpm --filter web... build` *(fails: Next.js requires react >= 19.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b794b26af48323a276515cedf99a96