### PR TITLE
feat(waha): add Dockerfile

### DIFF
--- a/services/waha/Dockerfile
+++ b/services/waha/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20 AS build
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY services ./services
+COPY packages ./packages
+RUN corepack enable && pnpm install --filter waha...
+RUN pnpm build
+
+FROM node:20 AS runtime
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/packages ./packages
+COPY --from=build /app/services/waha/dist ./services/waha/dist
+WORKDIR /app/services/waha
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- add Dockerfile for waha service using Node 20

## Testing
- `pnpm test`
- `pnpm build --filter waha` (fails: We did not find a package manager specified in your root package.json.)

------
https://chatgpt.com/codex/tasks/task_e_68b794b675ec8323838a6d41a212f6fd